### PR TITLE
Add Run-Anything implementation

### DIFF
--- a/protocol/src/main/kotlin/model/rider/NukeModel.kt
+++ b/protocol/src/main/kotlin/model/rider/NukeModel.kt
@@ -35,5 +35,8 @@ object NukeModel : Ext(Solution) {
             field("description", string.nullable)
             field("defaultValue", string.nullable)
         }))
+        
+        call("complete", string, array(string)).async
     }
+
 }

--- a/src/dotnet/ReSharper.Nuke/Rider/NukeModel.Generated.cs
+++ b/src/dotnet/ReSharper.Nuke/Rider/NukeModel.Generated.cs
@@ -34,48 +34,58 @@ namespace ReSharper.Nuke.Rider
     [NotNull] public ISignal<BuildInvocation> Build => _Build;
     [NotNull] public IViewableProperty<NukeTarget[]> Targets => _Targets;
     [NotNull] public IViewableProperty<NukeParameter[]> Parameters => _Parameters;
+    [NotNull] public RdEndpoint<string, string[]> Complete => _Complete;
     
     //private fields
     [NotNull] private readonly RdSignal<BuildInvocation> _Build;
     [NotNull] private readonly RdProperty<NukeTarget[]> _Targets;
     [NotNull] private readonly RdProperty<NukeParameter[]> _Parameters;
+    [NotNull] private readonly RdEndpoint<string, string[]> _Complete;
     
     //primary constructor
     private NukeModel(
       [NotNull] RdSignal<BuildInvocation> build,
       [NotNull] RdProperty<NukeTarget[]> targets,
-      [NotNull] RdProperty<NukeParameter[]> parameters
+      [NotNull] RdProperty<NukeParameter[]> parameters,
+      [NotNull] RdEndpoint<string, string[]> complete
     )
     {
       if (build == null) throw new ArgumentNullException("build");
       if (targets == null) throw new ArgumentNullException("targets");
       if (parameters == null) throw new ArgumentNullException("parameters");
+      if (complete == null) throw new ArgumentNullException("complete");
       
       _Build = build;
       _Targets = targets;
       _Parameters = parameters;
+      _Complete = complete;
       _Targets.OptimizeNested = true;
       _Parameters.OptimizeNested = true;
+      _Complete.Async = true;
       BindableChildren.Add(new KeyValuePair<string, object>("build", _Build));
       BindableChildren.Add(new KeyValuePair<string, object>("targets", _Targets));
       BindableChildren.Add(new KeyValuePair<string, object>("parameters", _Parameters));
+      BindableChildren.Add(new KeyValuePair<string, object>("complete", _Complete));
     }
     //secondary constructor
     internal NukeModel (
     ) : this (
       new RdSignal<BuildInvocation>(BuildInvocation.Read, BuildInvocation.Write),
       new RdProperty<NukeTarget[]>(ReadNukeTargetArray, WriteNukeTargetArray),
-      new RdProperty<NukeParameter[]>(ReadNukeParameterArray, WriteNukeParameterArray)
+      new RdProperty<NukeParameter[]>(ReadNukeParameterArray, WriteNukeParameterArray),
+      new RdEndpoint<string, string[]>(JetBrains.Rd.Impl.Serializers.ReadString, JetBrains.Rd.Impl.Serializers.WriteString, ReadStringArray, WriteStringArray)
     ) {}
     //statics
     
     public static CtxReadDelegate<NukeTarget[]> ReadNukeTargetArray = NukeTarget.Read.Array();
     public static CtxReadDelegate<NukeParameter[]> ReadNukeParameterArray = NukeParameter.Read.Array();
+    public static CtxReadDelegate<string[]> ReadStringArray = JetBrains.Rd.Impl.Serializers.ReadString.Array();
     
     public static CtxWriteDelegate<NukeTarget[]> WriteNukeTargetArray = NukeTarget.Write.Array();
     public static CtxWriteDelegate<NukeParameter[]> WriteNukeParameterArray = NukeParameter.Write.Array();
+    public static CtxWriteDelegate<string[]> WriteStringArray = JetBrains.Rd.Impl.Serializers.WriteString.Array();
     
-    protected override long SerializationHash => 4328651711297058255L;
+    protected override long SerializationHash => -6243300511775699317L;
     
     protected override Action<ISerializers> Register => RegisterDeclaredTypesSerializers;
     public static void RegisterDeclaredTypesSerializers(ISerializers serializers)
@@ -95,6 +105,7 @@ namespace ReSharper.Nuke.Rider
         printer.Print("build = "); _Build.PrintEx(printer); printer.Println();
         printer.Print("targets = "); _Targets.PrintEx(printer); printer.Println();
         printer.Print("parameters = "); _Parameters.PrintEx(printer); printer.Println();
+        printer.Print("complete = "); _Complete.PrintEx(printer); printer.Println();
       }
       printer.Print(")");
     }

--- a/src/rider/main/kotlin/com/jetbrains/rider/plugins/nuke/NukeConfigurationUtil.kt
+++ b/src/rider/main/kotlin/com/jetbrains/rider/plugins/nuke/NukeConfigurationUtil.kt
@@ -1,0 +1,55 @@
+package com.jetbrains.rider.plugins.nuke
+
+import com.intellij.execution.RunManager
+import com.intellij.execution.RunnerAndConfigurationSettings
+import com.intellij.execution.configurations.runConfigurationType
+import com.intellij.openapi.project.Project
+import com.intellij.openapi.util.io.FileUtil
+import com.jetbrains.rider.model.runnableProjectsModel
+import com.jetbrains.rider.projectView.solution
+import com.jetbrains.rider.run.configurations.project.DotNetProjectConfiguration
+
+fun findOrCreateConfiguration(
+    target: String,
+    runManager: RunManager,
+    project: Project,
+    projectFile: String,
+    arguments: String,
+    envs: Map<String, String>)
+    : RunnerAndConfigurationSettings =
+    runManager.findConfigurationByName(target) ?:
+        runManager.createAndAddConfiguration(
+            target,
+            project,
+            projectFile,
+            arguments,
+            envs
+        )
+
+private fun RunManager.createAndAddConfiguration(
+    name: String,
+    project: Project,
+    projectFile: String,
+    arguments: String,
+    envs: Map<String, String>): RunnerAndConfigurationSettings {
+
+    val configurationType = runConfigurationType<NukeBuildTargetConfigurationType>()
+    val configurationFactory = configurationType.configurationFactories.first()
+    val configuration = this.createConfiguration(name, configurationFactory)
+    configuration.isTemporary = true
+
+    val buildProjectFile = FileUtil.toSystemIndependentName(projectFile)
+    val dotnetProject = project.solution.runnableProjectsModel.projects.valueOrNull!!
+        .single { it -> it.projectFilePath == buildProjectFile }
+
+    val dotnetConfiguration = configuration.configuration as DotNetProjectConfiguration
+    dotnetConfiguration.parameters.projectFilePath = dotnetProject.projectFilePath
+    dotnetConfiguration.parameters.projectKind = dotnetProject.kind
+    dotnetConfiguration.parameters.programParameters = arguments
+    dotnetConfiguration.parameters.envs = envs
+
+    configuration.checkSettings()
+    this.addConfiguration(configuration)
+
+    return configuration
+}

--- a/src/rider/main/kotlin/com/jetbrains/rider/plugins/nuke/NukeModel.Generated.kt
+++ b/src/rider/main/kotlin/com/jetbrains/rider/plugins/nuke/NukeModel.Generated.kt
@@ -16,7 +16,8 @@ import kotlin.reflect.KClass
 class NukeModel private constructor(
     private val _build: RdSignal<BuildInvocation>,
     private val _targets: RdOptionalProperty<Array<NukeTarget>>,
-    private val _parameters: RdOptionalProperty<Array<NukeParameter>>
+    private val _parameters: RdOptionalProperty<Array<NukeParameter>>,
+    private val _complete: RdCall<String, Array<String>>
 ) : RdExtBase() {
     //companion
     
@@ -32,8 +33,9 @@ class NukeModel private constructor(
         
         private val __NukeTargetArraySerializer = NukeTarget.array()
         private val __NukeParameterArraySerializer = NukeParameter.array()
+        private val __StringArraySerializer = FrameworkMarshallers.String.array()
         
-        const val serializationHash = 4328651711297058255L
+        const val serializationHash = -6243300511775699317L
     }
     override val serializersOwner: ISerializersOwner get() = NukeModel
     override val serializationHash: Long get() = NukeModel.serializationHash
@@ -42,6 +44,7 @@ class NukeModel private constructor(
     val build: ISignal<BuildInvocation> get() = _build
     val targets: IOptProperty<Array<NukeTarget>> get() = _targets
     val parameters: IOptProperty<Array<NukeParameter>> get() = _parameters
+    val complete: IRdCall<String, Array<String>> get() = _complete
     //initializer
     init {
         _targets.optimizeNested = true
@@ -49,9 +52,14 @@ class NukeModel private constructor(
     }
     
     init {
+        _complete.async = true
+    }
+    
+    init {
         bindableChildren.add("build" to _build)
         bindableChildren.add("targets" to _targets)
         bindableChildren.add("parameters" to _parameters)
+        bindableChildren.add("complete" to _complete)
     }
     
     //secondary constructor
@@ -59,7 +67,8 @@ class NukeModel private constructor(
     ) : this(
         RdSignal<BuildInvocation>(BuildInvocation),
         RdOptionalProperty<Array<NukeTarget>>(__NukeTargetArraySerializer),
-        RdOptionalProperty<Array<NukeParameter>>(__NukeParameterArraySerializer)
+        RdOptionalProperty<Array<NukeParameter>>(__NukeParameterArraySerializer),
+        RdCall<String, Array<String>>(FrameworkMarshallers.String, __StringArraySerializer)
     )
     
     //equals trait
@@ -71,6 +80,7 @@ class NukeModel private constructor(
             print("build = "); _build.print(printer); println()
             print("targets = "); _targets.print(printer); println()
             print("parameters = "); _parameters.print(printer); println()
+            print("complete = "); _complete.print(printer); println()
         }
         printer.print(")")
     }

--- a/src/rider/main/kotlin/com/jetbrains/rider/plugins/nuke/NukeRunAnythingHelpGroup.kt
+++ b/src/rider/main/kotlin/com/jetbrains/rider/plugins/nuke/NukeRunAnythingHelpGroup.kt
@@ -1,0 +1,12 @@
+package com.jetbrains.rider.plugins.nuke
+
+import com.intellij.ide.actions.runAnything.activity.RunAnythingProvider
+import com.intellij.ide.actions.runAnything.groups.RunAnythingHelpGroup
+import com.intellij.util.containers.ContainerUtil
+
+class NukeRunAnythingHelpGroup : RunAnythingHelpGroup<NukeRunAnythingProvider>() {
+    override fun getProviders() =
+        ContainerUtil.immutableSingletonList(RunAnythingProvider.EP_NAME.findExtension(NukeRunAnythingProvider::class.java))
+
+    override fun getTitle() = ".NET"
+}

--- a/src/rider/main/kotlin/com/jetbrains/rider/plugins/nuke/NukeRunAnythingProvider.kt
+++ b/src/rider/main/kotlin/com/jetbrains/rider/plugins/nuke/NukeRunAnythingProvider.kt
@@ -1,0 +1,75 @@
+package com.jetbrains.rider.plugins.nuke
+
+import com.intellij.execution.DefaultExecutionTarget
+import com.intellij.execution.ExecutionManager
+import com.intellij.execution.RunManager
+import com.intellij.ide.actions.runAnything.RunAnythingAction.EXECUTOR_KEY
+import com.intellij.ide.actions.runAnything.RunAnythingUtil
+import com.intellij.ide.actions.runAnything.activity.RunAnythingProviderBase
+import com.intellij.ide.actions.runAnything.items.RunAnythingItem
+import com.intellij.openapi.actionSystem.DataContext
+import com.intellij.openapi.application.ApplicationManager
+import com.intellij.openapi.util.text.StringUtil
+import com.intellij.openapi.util.text.StringUtil.*
+import com.jetbrains.rider.model.runnableProjectsModel
+import com.jetbrains.rider.projectView.path
+import com.jetbrains.rider.projectView.solution
+import com.jetbrains.rider.util.idea.Project
+import java.io.File
+
+class NukeRunAnythingProvider : RunAnythingProviderBase<String?>() {
+    override fun getHelpCommandPlaceholder() = "nuke <target ...> <--parameter ...>"
+
+    override fun getCompletionGroupTitle() = "NUKE"
+
+    override fun getIcon(value: String) = NukeIcons.Icon
+
+    override fun getHelpIcon() = NukeIcons.Icon
+
+    override fun getHelpCommand() = "nuke"
+
+    override fun getValues(dataContext: DataContext, pattern: String): MutableCollection<String?> {
+        return if (!pattern.startsWith(helpCommand)) mutableListOf()
+        else dataContext.Project!!.solution.nukeModel.complete.sync(pattern)!!.toMutableList()
+
+    }
+
+    override fun execute(dataContext: DataContext, command: String) {
+        val commandToExecute = trimStart(command, helpCommand)
+        val project = RunAnythingUtil.fetchProject(dataContext)
+        val executionManager = ExecutionManager.getInstance(project)
+        val executor = EXECUTOR_KEY.getData(dataContext) ?: return
+
+        // HACK: Assume build project name
+        val buildProjectPath = project.solution.runnableProjectsModel.projects.valueOrNull!!.single { it -> it.projectFilePath.endsWith("_build.csproj") }.projectFilePath
+        val runManager = RunManager.getInstance(project)
+        val runConfiguration = findOrCreateConfiguration(
+            commandToExecute,
+            runManager,
+            project,
+            buildProjectPath,
+            commandToExecute,
+            emptyMap()
+        )
+
+        executionManager.restartRunProfile(
+            project,
+            executor,
+            DefaultExecutionTarget.INSTANCE,
+            runConfiguration,
+            null
+        )
+    }
+
+    override fun findMatchingValue(dataContext: DataContext, pattern: String): String? {
+        return if(pattern.startsWith(helpCommand)) getCommand(pattern) else null
+    }
+
+    override fun getMainListItem(dataContext: DataContext, value: String): RunAnythingItem {
+        return RunAnythingNukeItem(value)
+    }
+
+    override fun getCommand(command: String): String {
+        return command
+    }
+}

--- a/src/rider/main/kotlin/com/jetbrains/rider/plugins/nuke/RunAnythingNukeItem.kt
+++ b/src/rider/main/kotlin/com/jetbrains/rider/plugins/nuke/RunAnythingNukeItem.kt
@@ -1,0 +1,30 @@
+package com.jetbrains.rider.plugins.nuke
+
+import com.intellij.ide.actions.runAnything.items.RunAnythingItemBase
+import com.intellij.openapi.util.text.StringUtil
+import com.intellij.ui.SimpleColoredComponent
+import com.intellij.ui.SimpleTextAttributes
+import java.awt.Component
+
+class RunAnythingNukeItem(command: String) : RunAnythingItemBase(command, NukeIcons.Icon) {
+
+    override fun createComponent(isSelected: Boolean): Component {
+        val component = SimpleColoredComponent()
+        component.append(command)
+        component.appendTextPadding(20)
+        setupIcon(component, myIcon)
+
+        description?.let {
+            component.append(
+                " ${StringUtil.shortenTextWithEllipsis(it, 200, 0)}",
+                SimpleTextAttributes.GRAYED_ITALIC_ATTRIBUTES)
+        }
+
+        return component
+    }
+
+    override fun getDescription() : String? {
+        return null
+    }
+
+}

--- a/src/rider/main/kotlin/com/jetbrains/rider/plugins/nuke/RunConfigurationManager.kt
+++ b/src/rider/main/kotlin/com/jetbrains/rider/plugins/nuke/RunConfigurationManager.kt
@@ -1,16 +1,12 @@
 package com.jetbrains.rider.plugins.nuke
 
-import com.intellij.execution.configurations.runConfigurationType
 import com.intellij.execution.DefaultExecutionTarget
 import com.intellij.execution.ExecutionManager
 import com.intellij.execution.RunManager
-import com.intellij.execution.RunnerAndConfigurationSettings
 import com.intellij.execution.executors.DefaultDebugExecutor
 import com.intellij.execution.executors.DefaultRunExecutor
 import com.intellij.openapi.project.Project
-import com.intellij.openapi.util.io.FileUtil
 import com.jetbrains.rdclient.util.idea.LifetimedProjectComponent
-import com.jetbrains.rider.model.runnableProjectsModel
 import com.jetbrains.rider.projectView.solution
 import com.jetbrains.rider.run.configurations.project.DotNetProjectConfiguration
 
@@ -18,20 +14,25 @@ class RunConfigurationManager(project: Project, private val runManager: RunManag
     init {
         project.solution.nukeModel.build.advise(componentLifetime) { buildInvocation ->
             var configuration = runManager.findConfigurationByName(buildInvocation.target)
-                ?: createAndAddConfiguration(
+                ?: findOrCreateConfiguration(
+                    buildInvocation.target,
+                    runManager,
+                    project,
                     buildInvocation.target,
                     buildInvocation.projectFile,
-                    buildInvocation.target,
-                    hashMapOf())
+                    emptyMap()
+                )
 
             if (buildInvocation.skipDependencies) {
                 val dotnetConfiguration = configuration.configuration as DotNetProjectConfiguration
-                configuration = createAndAddConfiguration(
-                        dotnetConfiguration.name + " (Temp)",
-                        dotnetConfiguration.parameters.projectFilePath,
-                        dotnetConfiguration.parameters.programParameters + " --skip",
-                        dotnetConfiguration.parameters.envs)
-                runManager.addConfiguration(configuration)
+                configuration = findOrCreateConfiguration(
+                    dotnetConfiguration.name + " (Temp)",
+                    runManager,
+                    project,
+                    dotnetConfiguration.parameters.projectFilePath,
+                    dotnetConfiguration.parameters.programParameters + " --skip",
+                    dotnetConfiguration.parameters.envs)
+
             }
 
             runManager.selectedConfiguration = configuration
@@ -50,32 +51,5 @@ class RunConfigurationManager(project: Project, private val runManager: RunManag
                 runManager.selectedConfiguration = runManager.findConfigurationByName(buildInvocation.target)
             }
         }
-    }
-
-    private fun createAndAddConfiguration(
-        name: String,
-        projectFile: String,
-        arguments: String,
-        envs: Map<String, String>): RunnerAndConfigurationSettings {
-
-        val configurationType = runConfigurationType<NukeBuildTargetConfigurationType>()
-        val configurationFactory = configurationType.configurationFactories.first()
-        val configuration = runManager.createConfiguration(name, configurationFactory)
-        configuration.isTemporary = true
-
-        val buildProjectFile = FileUtil.toSystemIndependentName(projectFile)
-        var dotnetProject = project.solution.runnableProjectsModel.projects.valueOrNull!!
-                .single { it -> it.projectFilePath == buildProjectFile }
-
-        val dotnetConfiguration = configuration.configuration as DotNetProjectConfiguration
-        dotnetConfiguration.parameters.projectFilePath = dotnetProject.projectFilePath
-        dotnetConfiguration.parameters.projectKind = dotnetProject.kind
-        dotnetConfiguration.parameters.programParameters = arguments
-        dotnetConfiguration.parameters.envs = envs
-
-        configuration!!.checkSettings()
-        runManager.addConfiguration(configuration)
-
-        return configuration
     }
 }

--- a/src/rider/main/resources/META-INF/plugin.xml
+++ b/src/rider/main/resources/META-INF/plugin.xml
@@ -10,6 +10,8 @@
 
   <extensions defaultExtensionNs="com.intellij">
     <configurationType implementation="com.jetbrains.rider.plugins.nuke.NukeBuildTargetConfigurationType"/>
+    <runAnything.executionProvider implementation="com.jetbrains.rider.plugins.nuke.NukeRunAnythingProvider" />
+    <runAnything.helpGroup implementation="com.jetbrains.rider.plugins.nuke.NukeRunAnythingHelpGroup" />
   </extensions>
   <project-components>
     <component>


### PR DESCRIPTION
TODOS:

- [x] Register `RunAnything` for nuke
- [x] Build components with dummy targets
- [ ] Get actual targets from `shell-completion.yml`
- [ ] Run targets
- [ ] Get target description if provided (does this currently generated into the completion file?)

Thats what the current implementation with dummy targets look like:

![grafik](https://user-images.githubusercontent.com/2401875/50740150-ab91f680-11ea-11e9-862a-a7541c075fea.png)

![grafik](https://user-images.githubusercontent.com/2401875/50740158-bea4c680-11ea-11e9-98a9-2ba15c735b3f.png)
